### PR TITLE
Replace ReactDOM.findDOMNode with React.createRef

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -1,6 +1,5 @@
 // @flow
 import React from "react";
-import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { DraggableCore } from "react-draggable";
 import { Resizable } from "react-resizable";
@@ -175,6 +174,11 @@ export default class GridItem extends React.Component<Props, State> {
 
   currentNode: HTMLElement;
 
+  constructor(props) {
+    super(props);
+    this.currentNode = React.createRef();
+  }
+
   componentDidUpdate(prevProps: Props) {
     if (this.props.droppingPosition && prevProps.droppingPosition) {
       this.moveDroppingItem(prevProps);
@@ -189,18 +193,13 @@ export default class GridItem extends React.Component<Props, State> {
       return;
     }
 
-    if (!this.currentNode) {
-      // eslint-disable-next-line react/no-find-dom-node
-      this.currentNode = ((ReactDOM.findDOMNode(this): any): HTMLElement);
-    }
-
     const shouldDrag =
       (dragging && droppingPosition.x !== prevProps.droppingPosition.x) ||
       droppingPosition.y !== prevProps.droppingPosition.y;
 
     if (!dragging) {
       this.onDragStart(droppingPosition.e, {
-        node: this.currentNode,
+        node: this.currentNode.current,
         deltaX: droppingPosition.x,
         deltaY: droppingPosition.y
       });
@@ -209,7 +208,7 @@ export default class GridItem extends React.Component<Props, State> {
       const deltaY = droppingPosition.y - dragging.top;
 
       this.onDrag(droppingPosition.e, {
-        node: this.currentNode,
+        node: this.currentNode.current,
         deltaX,
         deltaY
       });

--- a/lib/components/WidthProvider.jsx
+++ b/lib/components/WidthProvider.jsx
@@ -1,7 +1,6 @@
 // @flow
 import React from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 import type { ComponentType as ReactComponentType } from "react";
 
 type WPProps = {
@@ -40,6 +39,11 @@ export default function WidthProvider<
 
     mounted: boolean = false;
 
+    constructor(props) {
+      super(props);
+      this.currentNode = React.createRef();
+    }
+
     componentDidMount() {
       this.mounted = true;
 
@@ -58,7 +62,7 @@ export default function WidthProvider<
     onWindowResize = () => {
       if (!this.mounted) return;
       // eslint-disable-next-line react/no-find-dom-node
-      const node = ReactDOM.findDOMNode(this); // Flow casts this to Text | Element
+      const node = this.currentNode.current; // Flow casts this to Text | Element
       if (node instanceof HTMLElement)
         this.setState({ width: node.offsetWidth });
     };

--- a/package.json
+++ b/package.json
@@ -78,6 +78,10 @@
     "webpack-cli": "^3.3.9",
     "webpack-dev-server": "^3.9.0"
   },
+  "peerDependencies": {
+    "react": ">=16.3.0",
+    "react-dom": ">=16.3.0"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },


### PR DESCRIPTION
# Issue:
`ReactDOM.findDOMNode` will be deprecated in the recent future.

# Solution:
To use `React.createRef` instead.